### PR TITLE
Allow usage of string interpolation

### DIFF
--- a/Youdot/ruleset.xml
+++ b/Youdot/ruleset.xml
@@ -34,6 +34,10 @@
             <property name="spacesCountBeforeColon" value="0"/>
         </properties>
     </rule>
+         
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar" />
+    </rule>
 
     <rule ref="Squiz.Commenting.FunctionComment">
         <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>


### PR DESCRIPTION
TL;DR : Interpolation is faster and more readable in php7

https://github.com/squizlabs/PHP_CodeSniffer/issues/2316

https://blog.blackfire.io/php-7-performance-improvements-encapsed-strings-optimization.html